### PR TITLE
:recycle: #3 引数のチェック処理を専用クラスに移動する

### DIFF
--- a/yumemi-codingtest/src/main/kotlin/ArgsChecker.kt
+++ b/yumemi-codingtest/src/main/kotlin/ArgsChecker.kt
@@ -1,0 +1,33 @@
+import java.io.File
+
+/** コマンドライン引数に指定できる有効な数 */
+private const val VALID_ARGS: Int = 2
+
+/**
+ * コマンドライン引数のチェッカークラスです。
+ * フィールドにはコマンドライン引数を持ちます。
+ */
+class ArgsChecker(private val commandLineArgs: Array<String>) {
+    /**
+     * コマンドラインより渡ってきた引数が有効であるかを判定します。
+     * 以下全てを満たしている場合、有効と判定し true を返します。
+     * - 引数の配列の要素数が 2 である
+     * - 引数の各要素のファイルパスが存在し、ファイルである
+     *
+     * @return コマンドライン引数の各要素が存在するファイルの場合 true
+     */
+    fun validArgs(): Boolean {
+        // 引数の数が妥当か
+        if (commandLineArgs.size != VALID_ARGS) {
+            return false
+        }
+        // ファイルの存在チェック
+        for (filePath: String in commandLineArgs) {
+            val file = File(filePath)
+            if (!file.exists() || file.isDirectory) {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/yumemi-codingtest/src/main/kotlin/Main.kt
+++ b/yumemi-codingtest/src/main/kotlin/Main.kt
@@ -1,5 +1,3 @@
-import java.io.File
-
 /**
  * メイン関数
  *
@@ -9,32 +7,9 @@ import java.io.File
 fun main(args: Array<String>) {
     // 引数の正当性チェック
     // ファイルの存在チェック
-    if (!validArgs(args)) {
+    val checker = ArgsChecker(args)
+    if (!checker.validArgs()) {
         // エラー処理
     }
     // 引数ファイルの内容チェック
-}
-
-/**
- * コマンドラインより渡ってきた引数が有効であるかを判定します。
- * 以下全てを満たしている場合、有効と判定し true を返します。
- * - 引数の配列の要素数が 2 である
- * - 引数の各要素のファイルパスが存在し、ファイルである
- *
- * @param[args] コマンドライン引数
- * @return コマンドライン引数の各要素が存在するファイルの場合 true
- */
-private fun validArgs(args: Array<String>): Boolean {
-    // 引数の数が妥当か
-    if (args.size != 2) {
-        return false
-    }
-    // ファイルの存在チェック
-    for (filePath in args) {
-        val file: File = File(filePath)
-        if (!file.exists() || file.isDirectory) {
-            return false
-        }
-    }
-    return true
 }


### PR DESCRIPTION
## 概要
main 関数のファイルには main() のみを定義するようにし、引数のチェッククラスを追加して移動しました。