### PR TITLE
:sparkles: #8 ファイル読み込み時の異常系処理を追加する

### DIFF
--- a/yumemi-codingtest/src/main/kotlin/Main.kt
+++ b/yumemi-codingtest/src/main/kotlin/Main.kt
@@ -1,6 +1,6 @@
+import constant.ErrorCode
 import model.EntryPlayer
 import model.PlayLog
-import java.io.IOException
 
 /**
  * メイン関数
@@ -22,14 +22,11 @@ fun main(args: Array<String>) {
         val importer = FileImporter(args)
         val entryPlayers: List<EntryPlayer> = importer.fileToEntryPlayer()
         val playLogs: List<PlayLog> = importer.fileToPlayLog()
-        if (entryPlayers.isNotEmpty() && playLogs.isNotEmpty()){
-            println("取り込み成功")
-        } else {
-            println("取り込み失敗")
+        if (entryPlayers.isEmpty()) {
+            println(ErrorCode.EMPTY_PLAYER_FILE.message)
+        } else if (playLogs.isEmpty()) {
+            println(ErrorCode.EMPTY_PLAY_LOG_FILE.message)
         }
-        return
-    } catch (e: IOException) {
-        println(e.message)
     } catch (e: IllegalArgumentException) {
         println(e.message)
     }

--- a/yumemi-codingtest/src/main/kotlin/constant/errorCode.kt
+++ b/yumemi-codingtest/src/main/kotlin/constant/errorCode.kt
@@ -7,5 +7,7 @@ enum class ErrorCode(val message: String) {
     INVALID_ARGS_SIZE("入力引数の数が不正です。"),
     NOT_FOUND("ログファイルが存在しません。"),
     INVALID_HEADER("ログファイルのヘッダーが不正です。"),
+    EMPTY_PLAYER_FILE("エントリーファイルにデータが存在しません。"),
+    EMPTY_PLAY_LOG_FILE("プレイログファイルにデータが存在しません。"),
     VALID("")
 }


### PR DESCRIPTION
## 概要
ファイルの中身が空の場合のエラー出力のみ実装出来ていなかったので、ファイルを読み込んだ結果、
各データクラスを持つListが空であれば、エラー出力するようにしました。
また、ファイル読み込み時にIOExceptionをcatchするように実装していましたが、公式ドキュメントを
参照したところ、throwされなかったため、削除しました。
Fileオブジェクト生成時にNPEが発生する可能性がありますが、事前にファイルの存在チェックを行っているため、
発生することはないのでcatchしていません。

## 参考ページ
https://developer.android.com/reference/kotlin/java/io/File#File(kotlin.String)
https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.io/java.io.-file/read-lines.html