### PR TITLE
:recycle: #3 2ファイルの内容を1クラスで保持するように変更する

### DIFF
--- a/yumemi-codingtest/src/main/kotlin/Main.kt
+++ b/yumemi-codingtest/src/main/kotlin/Main.kt
@@ -1,6 +1,7 @@
 import constant.ErrorCode
 import model.EntryPlayer
 import model.PlayLog
+import model.Player
 import model.RankerList
 
 /**
@@ -21,9 +22,8 @@ fun main(args: Array<String>) {
     // ファイルの変換、内容チェック
     try {
         val importer = FileImporter(args)
-        val entryPlayers: List<EntryPlayer> = importer.fileToEntryPlayer()
-        val playLogs: List<PlayLog> = importer.fileToPlayLog()
-        val aggregator = ScoreAggregator(entryPlayers, playLogs)
+        val players: List<Player> = importer.import()
+        val aggregator = ScoreAggregator(players)
         aggregator.aggregate().outputRanker()
     } catch (e: IllegalArgumentException) {
         println(e.message)

--- a/yumemi-codingtest/src/main/kotlin/ScoreAggregator.kt
+++ b/yumemi-codingtest/src/main/kotlin/ScoreAggregator.kt
@@ -1,16 +1,17 @@
-import model.EntryPlayer
-import model.PlayLog
-import model.RankerList
+import model.*
 
 /**
  * プレイログを元にスコアの集計を行うクラスです。
  */
 class ScoreAggregator(
-    /** エントリープレイヤー一覧 */
-    private val entryPlayers: List<EntryPlayer>,
-    /** プレイログ一覧 */
-    private val playLogs: List<PlayLog>
+    /** プレイヤー一覧 */
+    private val players: List<Player>
 ) {
+
+    companion object {
+        /** 上位ランカーの上限数 */
+        private const val MAX_RANKERS: Int = 10
+    }
 
     /**
      * プレイログの内容を元に集計を行います。
@@ -19,21 +20,61 @@ class ScoreAggregator(
      */
     fun aggregate(): RankerList {
         // プレイログを元に順位付けする
-        val sortedPlayLogs: List<PlayLog> = playLogs.sortedDescending()
+        val sortedPlayers: List<Player> = players.sortedDescending()
 
-        return extractTop10()
+        return extractTop10(sortedPlayers)
     }
 
     /**
      * 上位１０名のプレイヤーを抽出します。
      *
-     * @param[sortedPlayLogs] スコア降順でソートしたプレイログ
+     * @param[sortedPlayers] スコア降順でソートしたプレイヤー
      * @return 上位10名のプレイヤー一覧
      */
-    private fun extractTop10(sortedPlayLogs: List<PlayLog>): RankerList {
+    private fun extractTop10(sortedPlayers: List<Player>): RankerList {
         // エントリープレイヤーはハンドルネーム取得用
         // IDからハンドルネームを特定する
         // エントリープレイヤーに存在しないIDの場合はスキップする
-        return RankerList(listOf())
+        val rankerList: MutableList<Ranker> = mutableListOf()
+        var rank = 1
+        var lastScore = 0
+
+        for (player: Player in sortedPlayers) {
+            // 存在しないプレイヤーはスキップ
+            if (player.handleName.isEmpty()) {
+                continue
+            }
+
+            val score: Int = player.score
+            // 前回と違うスコアであれば順位更新
+            if (score != lastScore) {
+                rank = determineNextRank(rank, rankerList.size)
+            }
+            rankerList.add(Ranker(rank, player.playerId, player.handleName, player.score))
+            lastScore = score
+            // ランカーが10人を超えた時点で終了
+            if (rankerList.size > MAX_RANKERS) {
+                break
+            }
+            // TODO: 10人超えても次のプレイヤーのスコアが同点だった場合の考慮が不足
+            // TODO: ハンドルネームの取得
+
+        }
+        return RankerList(rankerList)
+    }
+
+    /**
+     * 現在の順位と既に決定しているランカーの数から
+     * 次の順位を決定します。
+     *
+     * @param[nowRank] 現在の順位
+     * @param[determinedRankers] 既に決定している上位プレイヤー
+     * @return 次の順位
+     */
+    private fun determineNextRank(nowRank: Int, determinedRankers: Int): Int {
+        if (determinedRankers == 0) {
+            return nowRank
+        }
+        return determinedRankers + 1
     }
 }

--- a/yumemi-codingtest/src/main/kotlin/model/Player.kt
+++ b/yumemi-codingtest/src/main/kotlin/model/Player.kt
@@ -1,0 +1,25 @@
+package model
+
+import java.time.LocalDateTime
+
+/**
+ * プレイヤーのデータクラスです。
+ */
+data class Player(
+    /** プレイヤーID */
+    val playerId: String,
+    /** ハンドルネーム */
+    val handleName: String,
+    /** スコア */
+    val score: Int,
+    /** ゲームのプレイ日時 */
+    val createTime: LocalDateTime
+) : Comparable<Player> {
+    override fun compareTo(other: Player): Int {
+        return if (score == other.score) {
+            0
+        } else {
+            score - other.score
+        }
+    }
+}


### PR DESCRIPTION
# 概要
結果の出力情報を作成する際に、現在のつくりだとプレイヤーIDに紐づくハンドルネームを取得するのが
不便であるため、ファイルインポート時に2ファイルを2クラスで保持するのではなく、1クラス(Player)で保持するように
修正しました。
そのため、わざわざEntryPlayerを1つずつ見なくても、直ぐにプレイヤーIDに紐づくハンドルネームを
取得できるようにしました。