### PR TITLE
:bug: #10 スコアが同点の場合player_idの降順になる不具合を修正する

### DIFF
--- a/app/src/main/kotlin/yumemi/codingtest/kotlin/model/Player.kt
+++ b/app/src/main/kotlin/yumemi/codingtest/kotlin/model/Player.kt
@@ -19,7 +19,7 @@ data class Player(
         return if (score != other.score) {
             score - other.score
         } else {
-            playerId.compareTo(other.playerId)
+            other.playerId.compareTo(playerId)
         }
     }
 }


### PR DESCRIPTION
## 概要
スコアが同点の場合、結果には player_id の昇順で出力しますが、現在は降順で出力するようになっています。
Playerオブジェクトの並び替えの条件を修正します。

### 修正内容
compareTo() の引数に渡すのを引数で渡ってきたPlayer(other)ではなく、自身を渡すようにします。

## メモ
なぜ、入れ替えないと想定の動作にならないかは理解出来ていないため、調べる